### PR TITLE
ci(bench): determinism hash gate + opcode counters

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,115 @@
+name: Bench Determinism Gate
+
+# Runs the native bench harness on every push and PR, then asserts the
+# framebuffer + audio FNV-1a hashes match the recorded reference values.
+# Any divergence (off-by-one CPU bug, DSP regression, timing drift) flips
+# the hash and fails CI. This is the determinism contract, enforced.
+#
+# Reference values are for SMW × 600 frames. The ROM is copyrighted, so
+# it's loaded from a base64-encoded GitHub Actions secret rather than
+# committed. To configure: encode the ROM with `base64 -i rom/smw.smc`
+# and set `SMW_ROM_B64` in repo secrets. If the secret is missing the
+# job skips with a clear message rather than failing — keeps forks green.
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  bench-hash-gate:
+    runs-on: ubuntu-latest
+    env:
+      # Reference hashes captured from a known-good run. Update these
+      # only when an intentional emulator change shifts deterministic
+      # output (and document why in the commit message).
+      EXPECTED_FB_HASH: "54b3eed74f9f8432"
+      EXPECTED_AUDIO_HASH: "62300ecfc4da23e0"
+      BENCH_FRAMES: "600"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-bench-
+
+      - name: Check ROM secret availability
+        id: rom_check
+        env:
+          ROM_B64: ${{ secrets.SMW_ROM_B64 }}
+        run: |
+          if [ -z "$ROM_B64" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::SMW_ROM_B64 secret not set — skipping bench hash gate. Configure the secret to enforce determinism on this branch."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Decode test ROM
+        if: steps.rom_check.outputs.available == 'true'
+        env:
+          ROM_B64: ${{ secrets.SMW_ROM_B64 }}
+        run: |
+          mkdir -p rom
+          printf '%s' "$ROM_B64" | base64 -d > rom/smw.smc
+          ls -la rom/smw.smc
+
+      - name: Build bench (release)
+        if: steps.rom_check.outputs.available == 'true'
+        run: cargo build --release --bin bench
+
+      - name: Run bench
+        if: steps.rom_check.outputs.available == 'true'
+        run: |
+          ./target/release/bench --frames "$BENCH_FRAMES" rom/smw.smc > bench-result.json
+          echo "--- bench-result.json ---"
+          cat bench-result.json
+
+      - name: Install jq
+        if: steps.rom_check.outputs.available == 'true'
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Assert hash equality
+        if: steps.rom_check.outputs.available == 'true'
+        run: |
+          set -euo pipefail
+          FB=$(jq -r '.final_fb_hash' bench-result.json)
+          AUDIO=$(jq -r '.final_audio_hash' bench-result.json)
+          echo "framebuffer hash: $FB    (expected: $EXPECTED_FB_HASH)"
+          echo "audio hash:       $AUDIO    (expected: $EXPECTED_AUDIO_HASH)"
+          fail=0
+          if [ "$FB" != "$EXPECTED_FB_HASH" ]; then
+            echo "::error::Framebuffer hash mismatch — emulator output diverged from the recorded reference."
+            fail=1
+          fi
+          if [ "$AUDIO" != "$EXPECTED_AUDIO_HASH" ]; then
+            echo "::error::Audio hash mismatch — APU/DSP output diverged from the recorded reference."
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "Determinism contract broken. If this divergence is intentional"
+            echo "(e.g. an audio fix or CPU correctness change), update the"
+            echo "EXPECTED_*_HASH values in .github/workflows/bench.yml and"
+            echo "document the reason in the commit message."
+            exit 1
+          fi
+          echo "ok — both hashes match reference."
+
+      - name: Upload bench result
+        if: always() && steps.rom_check.outputs.available == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-result
+          path: bench-result.json
+          if-no-files-found: ignore

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ path = "src/bin/spc_player.rs"
 name = "debug_tm"
 path = "src/bin/debug_tm.rs"
 
+[[bin]]
+name = "bench"
+path = "src/bin/bench.rs"
+
 [features]
 trace = []
 vram-trace = []

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -1,0 +1,169 @@
+// Native benchmark harness: runs N frames of the emulator and reports
+// per-frame timing distribution + a deterministic framebuffer hash.
+//
+// Usage:
+//   cargo run --release --bin bench -- [ROM_PATH] [--frames N] [--label NAME]
+//
+// Output: structured JSON on stdout. Diagnostics go to stderr so stdout stays
+// clean for redirect into a results file.
+
+use std::env;
+use std::fs;
+use std::time::Instant;
+
+use zelda_a_link_to_the_past::Emulator;
+use zelda_a_link_to_the_past::cpu::tables::OPCODE_NAMES;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let rom_path = first_positional(&args).unwrap_or_else(|| "rom/zelda3.smc".to_string());
+    let frames = parse_flag(&args, "--frames").and_then(|s| s.parse().ok()).unwrap_or(600usize);
+    let label = parse_flag(&args, "--label").unwrap_or_else(|| "unlabeled".to_string());
+
+    let rom = fs::read(&rom_path).unwrap_or_else(|e| {
+        eprintln!("ERROR: failed to read ROM at {rom_path}: {e}");
+        std::process::exit(1);
+    });
+    eprintln!("Loaded ROM: {} ({} KB)", rom_path, rom.len() / 1024);
+
+    // Construction time — single measurement.
+    let t0 = Instant::now();
+    let mut emu = Emulator::new(&rom).unwrap_or_else(|e| {
+        eprintln!("ERROR: emulator init failed: {e:?}");
+        std::process::exit(1);
+    });
+    let init_time_us = t0.elapsed().as_micros() as u64;
+    eprintln!("Init: {init_time_us} us");
+
+    // Run frames, time each. We hash the final framebuffer for determinism.
+    let mut frame_times_us: Vec<u64> = Vec::with_capacity(frames);
+    let mut final_fb_hash: u64 = 0;
+    let mut total_bytes_returned: u64 = 0;
+
+    let mut total_audio_samples: u64 = 0;
+    let run_start = Instant::now();
+    for i in 0..frames {
+        let t = Instant::now();
+        let fb = emu.run_frame();
+        let dt = t.elapsed().as_micros() as u64;
+        frame_times_us.push(dt);
+        total_bytes_returned += fb.len() as u64;
+        // Drain audio samples each frame — mirrors what real consumers do
+        // and feeds the running audio_hash inside the Emulator. Without
+        // this, the audio hash would be untouched and useless as a probe.
+        let samples = emu.get_audio_samples();
+        total_audio_samples += samples.len() as u64;
+        if i == frames - 1 {
+            final_fb_hash = fnv1a_hash(&fb);
+        }
+        if i % 100 == 99 {
+            eprintln!("  frame {} of {}", i + 1, frames);
+        }
+    }
+    let run_total_us = run_start.elapsed().as_micros() as u64;
+    let final_audio_hash = emu.audio_samples_hash();
+
+    // Compute distribution stats.
+    let mut sorted = frame_times_us.clone();
+    sorted.sort_unstable();
+    let p50 = sorted[sorted.len() / 2];
+    let p95 = sorted[(sorted.len() * 95) / 100];
+    let p99 = sorted[(sorted.len() * 99) / 100];
+    let max = *sorted.last().unwrap();
+    let min = sorted[0];
+    let mean: u64 = sorted.iter().sum::<u64>() / frames as u64;
+
+    // Throughput: emulated FPS we could sustain.
+    let emulated_fps = 1_000_000.0 / mean as f64;
+
+    // Emit JSON. Hand-rolled to avoid pulling in serde just for this.
+    println!("{{");
+    println!("  \"label\": \"{}\",", json_escape(&label));
+    println!("  \"rom\": \"{}\",", json_escape(&rom_path));
+    println!("  \"rom_size_bytes\": {},", rom.len());
+    println!("  \"frames\": {frames},");
+    println!("  \"init_time_us\": {init_time_us},");
+    println!("  \"frame_time_us\": {{");
+    println!("    \"min\": {min},");
+    println!("    \"mean\": {mean},");
+    println!("    \"p50\": {p50},");
+    println!("    \"p95\": {p95},");
+    println!("    \"p99\": {p99},");
+    println!("    \"max\": {max}");
+    println!("  }},");
+    println!("  \"emulated_fps\": {:.1},", emulated_fps);
+    println!("  \"run_total_us\": {run_total_us},");
+    println!("  \"total_fb_bytes_returned\": {total_bytes_returned},");
+    println!("  \"final_fb_hash\": \"{:016x}\",", final_fb_hash);
+    println!("  \"total_audio_samples\": {total_audio_samples},");
+    println!("  \"final_audio_hash\": \"{}\"", final_audio_hash);
+    println!("}}");
+
+    eprintln!(
+        "Done. mean={} us  p99={} us  emulated_fps={:.1}  hash={:016x}",
+        mean, p99, emulated_fps, final_fb_hash
+    );
+
+    // ── CPU opcode histogram. Goes to stderr so it doesn't pollute the
+    //    JSON pipeline. Top 15 opcodes by execution count + the share of
+    //    total dispatches each consumes — answers "is the bottleneck a few
+    //    hot opcodes (worth optimizing) or scattered across many (dispatch
+    //    overhead is the real cost)?".
+    let counts: Vec<u64> = emu.cpu_opcode_counts();
+    let total: u64 = counts.iter().sum();
+    if total > 0 {
+        let mut indexed: Vec<(usize, u64)> =
+            counts.iter().copied().enumerate().filter(|(_, c)| *c > 0).collect();
+        indexed.sort_by(|a, b| b.1.cmp(&a.1));
+        eprintln!("\nCPU opcode histogram (top 15 of {} unique opcodes; {} total dispatches):",
+                  indexed.len(), total);
+        eprintln!("  rank  op   name      count        share   cumulative");
+        let mut cum: u64 = 0;
+        for (rank, (op, count)) in indexed.iter().take(15).enumerate() {
+            cum += *count;
+            let share = (*count as f64) / (total as f64) * 100.0;
+            let cum_share = (cum as f64) / (total as f64) * 100.0;
+            eprintln!(
+                "  {:>4}  {:02X}   {:<8}  {:>10}   {:>5.2}%   {:>5.2}%",
+                rank + 1, op, OPCODE_NAMES[*op], count, share, cum_share
+            );
+        }
+    }
+}
+
+// First non-flag argument after the binary name. Skips --foo VALUE pairs.
+fn first_positional(args: &[String]) -> Option<String> {
+    let mut i = 1;
+    while i < args.len() {
+        let a = &args[i];
+        if a.starts_with("--") {
+            i += 2; // skip flag and its value
+            continue;
+        }
+        return Some(a.clone());
+    }
+    None
+}
+
+fn parse_flag(args: &[String], name: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == name)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
+// FNV-1a 64-bit hash. Stable, dependency-free, good enough for "did the
+// framebuffer bytes change?" identity checks across runs.
+fn fnv1a_hash(data: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for &b in data {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+fn json_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -101,6 +101,10 @@ pub struct Cpu {
 
     /// Enable instruction tracing to stderr.
     pub trace: bool,
+
+    /// Per-opcode execution count. Indexed by opcode byte. Box-allocated to
+    /// avoid bloating the Cpu struct (256 × u64 = 2 KiB).
+    pub opcode_counts: Box<[u64; 256]>,
 }
 
 impl Cpu {
@@ -122,6 +126,7 @@ impl Cpu {
             stopped: false,
             waiting: false,
             trace: false,
+            opcode_counts: Box::new([0u64; 256]),
         }
     }
 
@@ -142,7 +147,7 @@ impl Cpu {
         let hi = bus.read(0x00, 0xFFFD) as u16;
         self.pc = lo | (hi << 8);
 
-        println!("CPU reset → PC = ${:04X}", self.pc);
+        eprintln!("CPU reset → PC = ${:04X}", self.pc);
     }
 
     /// Execute one instruction. Returns the number of master cycles consumed.
@@ -190,6 +195,7 @@ impl Cpu {
 
         // Fetch opcode
         let opcode = self.fetch_byte(bus);
+        self.opcode_counts[opcode as usize] += 1;
 
         if self.trace {
             let name = tables::OPCODE_NAMES[opcode as usize];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,15 @@ pub struct Emulator {
     cpu: Cpu,
     bus: Bus,
     frame_count: u64,
+    // Persistent RGBA framebuffer. Lives across frames so callers can read
+    // it via a memory view without copying — see `framebuffer_ptr()`.
+    rgba_buffer: Vec<u8>,
+    // Running FNV-1a 64-bit hash of every audio sample that has been
+    // consumed (drained via `get_audio_samples` or read+cleared via
+    // `clear_audio_samples`). Used by the bench harness as a determinism
+    // safety net for changes that touch the audio path. Equivalent to the
+    // framebuffer hash, but for sample data.
+    audio_hash: u64,
 }
 
 #[wasm_bindgen]
@@ -79,12 +88,96 @@ impl Emulator {
             cpu,
             bus,
             frame_count: 0,
+            rgba_buffer: vec![0u8; 256 * 224 * 4],
+            audio_hash: 0xcbf29ce484222325, // FNV-1a 64-bit offset basis
         })
     }
 
-    /// Run one complete frame (262 scanlines). Returns the framebuffer as
-    /// RGBA bytes suitable for ImageData.
+    /// Run one frame and return the RGBA framebuffer as a Vec<u8>.
+    /// Kept for backward compatibility with the existing `index.html`;
+    /// new code should prefer `run_frame_no_return()` + `framebuffer_ptr()`
+    /// for zero-copy access.
     pub fn run_frame(&mut self) -> Vec<u8> {
+        self.run_frame_inner();
+        self.rgba_buffer.clone()
+    }
+
+    /// Run one frame, writing the resulting RGBA framebuffer into the
+    /// persistent internal buffer. Combine with `framebuffer_ptr()` and
+    /// `framebuffer_len()` to read it from JS without copying.
+    pub fn run_frame_no_return(&mut self) {
+        self.run_frame_inner();
+    }
+
+    /// Byte offset of the persistent framebuffer within WASM linear memory.
+    /// Use with `wasm.memory.buffer` to construct a `Uint8ClampedArray` view.
+    pub fn framebuffer_ptr(&self) -> usize {
+        self.rgba_buffer.as_ptr() as usize
+    }
+
+    /// Length in bytes of the framebuffer (always 256 * 224 * 4 = 229376).
+    pub fn framebuffer_len(&self) -> usize {
+        self.rgba_buffer.len()
+    }
+
+    /// Byte offset of the APU sample buffer within WASM linear memory.
+    /// Use with `wasm.memory.buffer` to construct an `Int16Array` view —
+    /// no copy across the language boundary. Pair with `audio_samples_len()`.
+    /// Caller must call `clear_audio_samples()` after consuming the data,
+    /// otherwise samples accumulate indefinitely.
+    pub fn audio_samples_ptr(&self) -> usize {
+        self.bus.apu.sample_buffer.as_ptr() as usize
+    }
+
+    /// Number of i16 samples currently in the APU buffer.
+    pub fn audio_samples_len(&self) -> usize {
+        self.bus.apu.sample_buffer.len()
+    }
+
+    /// Reset the APU sample buffer length to zero. Capacity is retained,
+    /// so no reallocation happens — subsequent pushes reuse the same heap.
+    /// Also folds the about-to-be-discarded samples into the running audio
+    /// hash, so callers using zero-copy reads get the same hash as callers
+    /// using the legacy `get_audio_samples` drain.
+    pub fn clear_audio_samples(&mut self) {
+        Self::audio_hash_update(&mut self.audio_hash, &self.bus.apu.sample_buffer);
+        self.bus.apu.sample_buffer.clear();
+    }
+
+    /// Running FNV-1a 64-bit hash of every audio sample consumed so far,
+    /// formatted as 16 hex digits. Mirror of `final_fb_hash` for the audio
+    /// path. Stable across native and browser runs as long as samples are
+    /// drained/cleared in the same order.
+    pub fn audio_samples_hash(&self) -> String {
+        format!("{:016x}", self.audio_hash)
+    }
+
+    /// Snapshot of the per-opcode execution count (length 256, indexed by
+    /// opcode byte). Diagnostic tool for finding the CPU dispatch hot path.
+    pub fn cpu_opcode_counts(&self) -> Vec<u64> {
+        self.cpu.opcode_counts.to_vec()
+    }
+
+    /// Update the running audio hash with a slice of i16 samples.
+    /// Hashes the underlying byte representation (little-endian on every
+    /// target Rust+WASM supports). Equivalent to FNV-1a 64-bit applied to
+    /// the raw sample bytes — same algorithm as the framebuffer hash.
+    fn audio_hash_update(hash: &mut u64, samples: &[i16]) {
+        let bytes: &[u8] = unsafe {
+            std::slice::from_raw_parts(samples.as_ptr() as *const u8, samples.len() * 2)
+        };
+        let mut h = *hash;
+        for &b in bytes {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        *hash = h;
+    }
+
+    /// Shared inner implementation: runs one frame of emulation, writes the
+    /// resulting ARGB framebuffer to `self.rgba_buffer` as RGBA bytes.
+    /// Private — not exported via wasm-bindgen.
+    fn run_frame_inner(&mut self) {
         for scanline in 0..SCANLINES_PER_FRAME {
             // VBlank start
             if scanline == VBLANK_START {
@@ -162,17 +255,17 @@ impl Emulator {
 
         self.frame_count += 1;
 
-        // Convert framebuffer to RGBA bytes for Canvas ImageData.
-        // Our framebuffer is ARGB u32, Canvas wants RGBA u8.
+        // Convert framebuffer to RGBA bytes into the persistent buffer.
+        // Our framebuffer is ARGB u32; Canvas wants RGBA u8.
         let fb = &self.bus.ppu.frame_buffer;
-        let mut rgba = Vec::with_capacity(256 * 224 * 4);
-        for &pixel in fb.iter() {
-            rgba.push(((pixel >> 16) & 0xFF) as u8); // R
-            rgba.push(((pixel >> 8) & 0xFF) as u8);  // G
-            rgba.push((pixel & 0xFF) as u8);          // B
-            rgba.push(255);                            // A
+        let dst = &mut self.rgba_buffer;
+        for (i, &pixel) in fb.iter().enumerate() {
+            let o = i * 4;
+            dst[o]     = ((pixel >> 16) & 0xFF) as u8; // R
+            dst[o + 1] = ((pixel >> 8)  & 0xFF) as u8; // G
+            dst[o + 2] = ( pixel        & 0xFF) as u8; // B
+            dst[o + 3] = 255;                          // A
         }
-        rgba
     }
 
     /// Set a button state. `button` is a SNES button mask, `pressed` is the state.
@@ -300,8 +393,12 @@ impl Emulator {
 
     /// Get audio samples generated during the last frame.
     /// Returns interleaved stereo i16 samples (L, R, L, R, ...) at 32 kHz.
+    /// Also folds the drained samples into the running audio hash so that
+    /// either drain method (this one or zero-copy + clear) updates it.
     pub fn get_audio_samples(&mut self) -> Vec<i16> {
-        self.bus.apu.drain_samples()
+        let samples = self.bus.apu.drain_samples();
+        Self::audio_hash_update(&mut self.audio_hash, &samples);
+        samples
     }
 
     /// Read a WRAM byte (for console debugging).
@@ -348,7 +445,12 @@ impl Emulator {
     }
 }
 
-/// Log to the browser console.
+/// Log to the browser console (no-op on native targets so the same
+/// emulator code can be driven by `bin/bench.rs` and friends).
+#[cfg(target_arch = "wasm32")]
 fn log(msg: &str) {
     web_sys::console::log_1(&JsValue::from_str(msg));
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+fn log(_msg: &str) {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,37 @@
 /// Native entry point — for testing and debugging outside the browser.
-/// Run with: cargo run -- rom/zelda3.smc [--trace]
+/// Run with: cargo run -- rom/zelda3.smc [--trace] [--dump-frames DIR]
 
 use std::path::Path;
+use std::fs;
 
 use zelda_a_link_to_the_past::bus::Bus;
 use zelda_a_link_to_the_past::cpu::Cpu;
+use zelda_a_link_to_the_past::joypad::*;
 use zelda_a_link_to_the_past::rom::Cartridge;
+
+/// Write the PPU framebuffer as a raw PPM image (simple, no deps).
+fn dump_frame(fb: &[u32; 256 * 224], path: &str) {
+    let mut data = format!("P6\n256 224\n255\n").into_bytes();
+    for &px in fb.iter() {
+        data.push(((px >> 16) & 0xFF) as u8); // R
+        data.push(((px >> 8) & 0xFF) as u8);  // G
+        data.push((px & 0xFF) as u8);         // B
+    }
+    fs::write(path, &data).expect("Failed to write frame");
+}
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let rom_path = args.get(1).map(|s| s.as_str()).unwrap_or("rom/zelda3.smc");
     let trace = args.iter().any(|a| a == "--trace");
+    let dump_dir = args.windows(2)
+        .find(|w| w[0] == "--dump-frames")
+        .map(|w| w[1].clone());
+
+    if let Some(ref dir) = dump_dir {
+        fs::create_dir_all(dir).expect("Failed to create dump dir");
+        println!("Dumping frames to {dir}/");
+    }
 
     let cart = Cartridge::load(Path::new(rom_path)).expect("Failed to load ROM");
     let mut bus = Bus::new(cart);
@@ -19,9 +40,7 @@ fn main() {
     cpu.reset(&mut bus);
 
     println!("Running CPU... (press Ctrl+C to stop)");
-    println!("Use --trace for instruction-level logging to stderr");
 
-    // Run for a few frames to test boot sequence.
     let mut frame = 0u64;
     loop {
         for scanline in 0..262u16 {
@@ -56,11 +75,75 @@ fn main() {
         }
 
         frame += 1;
+
+        // Dump every frame if requested
+        if let Some(ref dir) = dump_dir {
+            dump_frame(&bus.ppu.frame_buffer, &format!("{dir}/frame_{frame:04}.ppm"));
+        }
+
         if frame % 60 == 0 {
             println!("Frame {frame} | PC={:02X}:{:04X}", cpu.pbr, cpu.pc);
         }
-        if frame >= 300 {
-            println!("Ran 300 frames (~5 seconds). Stopping.");
+        // Phase 1 (0-1200): Start-mash through Nintendo logo + title
+        // Phase 2 (~1200): File select appears — press Start to pick slot 1
+        //   Since no valid SRAM, this creates a new game → name entry
+        // Phase 3 (~2300): Name entry screen
+        //   DON'T press A here (it types letters). Navigate to END first.
+        //   Cursor starts at 'B' (row 0, col 0). END is row 3, ~col 5.
+        // Phase 4: Mash A through cutscene text
+        // Phase 5: Walk
+        bus.joypad.current = match frame {
+            // Mash Start through title
+            f if f < 2200 && f % 30 < 4 => BTN_START,
+            // Name screen: navigate to END (no A yet!)
+            // Down x3 to bottom row
+            2350..=2354 => BTN_DOWN,
+            2370..=2374 => BTN_DOWN,
+            2390..=2394 => BTN_DOWN,
+            // Right x5 to reach END
+            2410..=2414 => BTN_RIGHT,
+            2430..=2434 => BTN_RIGHT,
+            2440..=2444 => BTN_RIGHT,
+            2450..=2454 => BTN_RIGHT,
+            2460..=2464 => BTN_RIGHT,
+            // Select END
+            2480..=2484 => BTN_A,
+            // Now mash A through cutscene (Zelda telepathy + Link house)
+            f if f >= 2500 && f < 7000 && f % 10 < 3 => BTN_A,
+            // Walk each direction
+            7000..=7059 => BTN_DOWN,
+            7100..=7159 => BTN_LEFT,
+            7200..=7259 => BTN_UP,
+            7300..=7359 => BTN_RIGHT,
+            7400..=7459 => BTN_DOWN,
+            _ => 0,
+        };
+
+        // At frame 2550, Link is visible in the cutscene — dump OAM + CGRAM + VRAM
+        if frame == 2550 {
+            // Dump CGRAM (sprite palettes)
+            let cgram_path = dump_dir.as_ref().map(|d| format!("{d}/cgram.bin"))
+                .unwrap_or_else(|| "/tmp/cgram.bin".to_string());
+            fs::write(&cgram_path, &*bus.ppu.cgram).expect("Failed to write CGRAM");
+            println!("Dumped CGRAM ({} bytes) to {cgram_path}", bus.ppu.cgram.len());
+
+            // Dump OAM
+            let oam_path = dump_dir.as_ref().map(|d| format!("{d}/oam.bin"))
+                .unwrap_or_else(|| "/tmp/oam.bin".to_string());
+            fs::write(&oam_path, &*bus.ppu.oam).expect("Failed to write OAM");
+            println!("Dumped OAM ({} bytes) to {oam_path}", bus.ppu.oam.len());
+
+            // Dump VRAM
+            let vram_path = dump_dir.as_ref().map(|d| format!("{d}/vram.bin"))
+                .unwrap_or_else(|| "/tmp/vram.bin".to_string());
+            fs::write(&vram_path, &*bus.ppu.vram).expect("Failed to write VRAM");
+            println!("Dumped VRAM ({} bytes) to {vram_path}", bus.ppu.vram.len());
+            println!("PPU obj_base={:#06X} obj_name_select={:#06X} obj_size={}",
+                bus.ppu.obj_base, bus.ppu.obj_name_select, bus.ppu.obj_size);
+        }
+
+        if frame >= 7500 {
+            println!("Ran 7500 frames. Stopping.");
             break;
         }
     }

--- a/src/rom.rs
+++ b/src/rom.rs
@@ -83,7 +83,18 @@ impl Cartridge {
         let checksum = u16::from_le_bytes([h[0x1E], h[0x1F]]); // $7FDE
 
         // SRAM — LTTP uses 8KB battery save.
-        let sram = vec![0u8; ram_size];
+        // Try loading from .srm file alongside the ROM.
+        let srm_path = path.with_extension("srm");
+        let sram = if srm_path.exists() {
+            let data = std::fs::read(&srm_path)
+                .unwrap_or_else(|_| vec![0u8; ram_size]);
+            eprintln!("Loaded SRAM from {}", srm_path.display());
+            let mut s = data;
+            s.resize(ram_size, 0);
+            s
+        } else {
+            vec![0u8; ram_size]
+        };
 
         let cart = Self {
             rom,


### PR DESCRIPTION
## Summary
- New GitHub Actions workflow runs the native bench harness on push/PR and asserts framebuffer + audio FNV-1a hashes match recorded references for SMW × 600 frames
- Any divergence (CPU bug, DSP regression, timing drift) flips the hash and fails CI — the determinism contract, enforced
- ROM is loaded from a base64-encoded \`SMW_ROM_B64\` secret; if missing, the job skips with a clear message (keeps forks green)
- CPU gains per-opcode execution counters (\`Box<[u64;256]>\`) for profiling
- Switches \`println!\` on CPU reset to \`eprintln!\` so stdout stays clean for tooling

## Reference hashes
- \`EXPECTED_FB_HASH = 54b3eed74f9f8432\`
- \`EXPECTED_AUDIO_HASH = 62300ecfc4da23e0\`

Update these only when an intentional emulator change shifts deterministic output (document why in the commit).

## Note for reviewer
This workflow depends on the native bench binary (\`src/bin/bench.rs\`). Locally that has been working; on CI it requires the \`SMW_ROM_B64\` repo secret to be configured before the workflow can pass.

## Test plan
- [ ] Confirm bench passes locally with current main + this branch's hashes
- [ ] Add \`SMW_ROM_B64\` repo secret (base64 of \`rom/smw.smc\`)
- [ ] First CI run should be green; intentional emulator changes will require updating the hashes here