### PR TITLE
fix: remove duplicate [[bin]] bench from Cargo.toml + unused snapshot helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,14 +41,10 @@ trace = []
 vram-trace = []
 cpu-trace = []
 
-[profile.release]
-opt-level = 3
-lto = "thin"
-
-[[bin]]
-name = "bench"
-path = "src/bin/bench.rs"
-
 [[bin]]
 name = "snapshot_test"
 path = "src/bin/snapshot_test.rs"
+
+[profile.release]
+opt-level = 3
+lto = "thin"

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -42,8 +42,6 @@ const VERSION: u8 = 1;
 #[inline] pub(crate) fn w_u32(out: &mut Vec<u8>, v: u32) { out.extend_from_slice(&v.to_le_bytes()); }
 #[inline] pub(crate) fn w_u64(out: &mut Vec<u8>, v: u64) { out.extend_from_slice(&v.to_le_bytes()); }
 #[inline] pub(crate) fn w_i16(out: &mut Vec<u8>, v: i16) { out.extend_from_slice(&v.to_le_bytes()); }
-#[inline] pub(crate) fn w_i32(out: &mut Vec<u8>, v: i32) { out.extend_from_slice(&v.to_le_bytes()); }
-#[inline] pub(crate) fn w_i64(out: &mut Vec<u8>, v: i64) { out.extend_from_slice(&v.to_le_bytes()); }
 #[inline] pub(crate) fn w_bool(out: &mut Vec<u8>, v: bool) { out.push(if v { 1 } else { 0 }); }
 pub(crate) fn w_bytes(out: &mut Vec<u8>, b: &[u8]) {
     w_u32(out, b.len() as u32);
@@ -71,8 +69,6 @@ pub(crate) fn r_u64(r: &mut &[u8]) -> Result<u64, String> {
     Ok(u64::from_le_bytes(b))
 }
 pub(crate) fn r_i16(r: &mut &[u8]) -> Result<i16, String> { r_u16(r).map(|v| v as i16) }
-pub(crate) fn r_i32(r: &mut &[u8]) -> Result<i32, String> { r_u32(r).map(|v| v as i32) }
-pub(crate) fn r_i64(r: &mut &[u8]) -> Result<i64, String> { r_u64(r).map(|v| v as i64) }
 pub(crate) fn r_bool(r: &mut &[u8]) -> Result<bool, String> { r_u8(r).map(|v| v != 0) }
 pub(crate) fn r_bytes_into(r: &mut &[u8], dst: &mut [u8]) -> Result<(), String> {
     let n = r_u32(r)? as usize;


### PR DESCRIPTION
## What this fixes

### 1. \`Cargo.toml\` is currently unparseable on \`main\`

After PRs #11 and #10 both squash-merged, \`main\` ended up with **two** \`[[bin]] name = "bench"\` declarations (lines 35-37 and 48-50). Cargo refuses to parse the manifest at all:

\`\`\`
$ cargo check
error: failed to parse manifest at \`/.../rust-wasm-snes/Cargo.toml\`
Caused by:
  found duplicate binary name bench, but all binary targets must have a unique name
\`\`\`

This means **nothing on \`main\` actually builds locally right now.** Removed the second occurrence; kept \`snapshot_test\` in its canonical position before \`[profile.release]\`.

### 2. Drop 4 unused signed-int snapshot helpers

\`w_i32\`, \`w_i64\`, \`r_i32\`, \`r_i64\` in \`src/snapshot.rs\` had no callers anywhere in the workspace (verified via \`grep\`). The \`i16\` variants ARE used (PPU Mode 7 registers); the 32/64-bit signed helpers were unused. Deleted. Trivial to re-add when the first signed 32/64-bit snapshot field appears.

## How this got past CI — and the bigger issue

The \`bench-hash-gate\` workflow has this guard:

\`\`\`yaml
if [ -z "\${{ secrets.SMW_ROM_B64 }}" ]; then
  echo "::warning::SMW_ROM_B64 secret not set — skipping bench hash gate."
  exit 0
fi
\`\`\`

That was designed to keep forks green. But \`SMW_ROM_B64\` is also unset on **this** repo, so the workflow has been skipping its entire build step on every push since #9 merged. Every "🟢 SUCCESS" we've seen is a no-op — the determinism gate is not enforcing anything.

### Recommended follow-up (not in this PR)

To actually enforce the contract on \`main\`:

\`\`\`bash
base64 -i rom/smw.smc | gh secret set SMW_ROM_B64 --repo nickmeinhold/rust-wasm-snes
\`\`\`

I haven't done this myself because:
1. The ROM is copyrighted — uploading it to GH secrets is your call
2. The workflow's skip-when-missing is a sensible default for forks; the only thing missing is configuration on the main repo

Alternative: bake a hash of \`Cargo.lock\` + the source tree into the gate as a lower-tier check that runs without the ROM, so at least manifest-parse-level regressions get caught.

## Test plan

- [x] \`cargo check --all-targets\` clean
- [x] No \"never used\" warnings on \`w_i*\` / \`r_i*\`
- [ ] After merge, \`cargo run --release --bin bench rom/smw.smc\` produces \`final_fb_hash: 54b3eed74f9f8432\`, \`final_audio_hash: 62300ecfc4da23e0\`