### PR TITLE
ci: add cargo-check job that runs without ROM secret

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,15 +1,21 @@
 name: Bench Determinism Gate
 
-# Runs the native bench harness on every push and PR, then asserts the
-# framebuffer + audio FNV-1a hashes match the recorded reference values.
-# Any divergence (off-by-one CPU bug, DSP regression, timing drift) flips
-# the hash and fails CI. This is the determinism contract, enforced.
+# Two jobs:
+#
+# 1. `cargo-check` — manifest + type check. Runs unconditionally on
+#    every push/PR. Catches Cargo.toml parse errors, type errors, and
+#    warnings before the (optional) hash gate. No ROM needed.
+#
+# 2. `bench-hash-gate` — runs the native bench harness and asserts the
+#    framebuffer + audio FNV-1a hashes match the recorded references.
+#    Any divergence (off-by-one CPU bug, DSP regression, timing drift)
+#    flips the hash and fails CI. The determinism contract, enforced.
 #
 # Reference values are for SMW × 600 frames. The ROM is copyrighted, so
 # it's loaded from a base64-encoded GitHub Actions secret rather than
 # committed. To configure: encode the ROM with `base64 -i rom/smw.smc`
 # and set `SMW_ROM_B64` in repo secrets. If the secret is missing the
-# job skips with a clear message rather than failing — keeps forks green.
+# hash-gate job skips with a clear message — keeps forks green.
 
 on:
   push:
@@ -17,6 +23,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  cargo-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-check-
+
+      - name: cargo check --all-targets
+        run: cargo check --all-targets --locked
+
   bench-hash-gate:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Why

PR #13 just landed a fix for a duplicate \`[[bin]] bench\` in \`Cargo.toml\` that had been on \`main\` for ~16 hours. CI didn't catch it because the existing \`bench-hash-gate\` workflow skips its entire build step when \`SMW_ROM_B64\` is unset — and the secret is unset on this repo. So every recent push was reporting 🟢 SUCCESS while cargo couldn't even parse the manifest.

## What this adds

A second job, \`cargo-check\`, that runs unconditionally on every push/PR. It runs \`cargo check --all-targets --locked\` — catches:

- Manifest parse errors (today's bug)
- Type errors
- Lockfile drift (via \`--locked\`)
- Warnings introduced by new code

No ROM needed. Cost: ~30s/run, mostly cached. The hash-gate job is unchanged.

## After this lands

CI status checks on \`main\` will show two jobs: \`cargo-check\` (always meaningful) and \`bench-hash-gate\` (still skips without the ROM secret — see #13 for instructions to configure).

## Test plan

- [x] Locally: \`cargo check --all-targets --locked\` passes
- [ ] CI runs both jobs after merge; \`cargo-check\` reports actual success not skip